### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ env:
 jobs:
   build-and-release:
     name: Build and Release
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -83,6 +85,8 @@ jobs:
 
   create-release:
     name: Create Release
+    permissions:
+      contents: write
     needs: build-and-release
     runs-on: ubuntu-latest
     steps:
@@ -130,6 +134,8 @@ jobs:
 
   publish-to-crates-io:
     name: Publish to Crates.io
+    permissions:
+      contents: read
     needs: create-release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/rhysparry/jxcape/security/code-scanning/1](https://github.com/rhysparry/jxcape/security/code-scanning/1)

To fix this problem, you should add a `permissions:` block either at the workflow root for all jobs (as a default) or individually for each job depending on what actions the job needs to perform with `GITHUB_TOKEN`. For most jobs, `contents: read` is likely sufficient, but the `create-release` job (which creates a new release using `softprops/action-gh-release`) will require `contents: write`. Add explicit permissions to each job to limit what GITHUB_TOKEN can do:
- For `build-and-release` and `publish-to-crates-io`, add `permissions: contents: read`.
- For `create-release`, add `permissions: contents: write`.
These blocks should be placed immediately under each job definition (right after the job name), maintaining yaml indentation. No changes to imports or code are necessary, only workflow yaml structure.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
